### PR TITLE
fix: 권한에 따라 멤버 초대 취소를 분리

### DIFF
--- a/src/main/java/onepick/kanban/user/controller/AdminController.java
+++ b/src/main/java/onepick/kanban/user/controller/AdminController.java
@@ -14,21 +14,21 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/admins")
+@RequestMapping("/admins/workspaces")
 @RequiredArgsConstructor
 public class AdminController {
 
     private final AdminService adminService;
 
     // 워크스페이스 생성
-    @PostMapping("/workspaces")
+    @PostMapping
     public ResponseEntity<WorkspaceResponseDto> createWorkspace(@Valid @RequestBody WorkspaceRequestDto requestDto) {
         WorkspaceResponseDto responseDto = adminService.createWorkspace(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
     // 멤버 초대
-    @PostMapping("/workspaces/{workspaceId}/invite")
+    @PostMapping("/{workspaceId}/invite")
     public ResponseEntity<String> inviteMembersByAdmin(@PathVariable Long workspaceId,
                                                        @Valid @RequestBody InviteRequestDto requestDto) {
         adminService.inviteMembersByAdmin(workspaceId, requestDto.getEmails());
@@ -36,7 +36,7 @@ public class AdminController {
     }
 
     // admin 관리자가 member의 권한을 지정
-    @PutMapping("/workspaces/{workspaceId}/members/{memberId}/role")
+    @PutMapping("/{workspaceId}/members/{memberId}/role")
     public ResponseEntity<MemberRoleResponseDto> updateRole(@PathVariable Long workspaceId,
                                                             @PathVariable Long memberId,
                                                             @Valid @RequestBody MemberRoleRequestDto memberRoleRequestDto) {
@@ -44,8 +44,16 @@ public class AdminController {
     }
 
     // 워크스페이스의 멤버 전체 조회
-    @GetMapping("/workspaces/{workspaceId}/members")
+    @GetMapping("/{workspaceId}/members")
     public ResponseEntity<MemberResponseDto> findMemberByWorkspaceId(@PathVariable Long workspaceId) {
         return ResponseEntity.ok().body(adminService.findMemberByWorkspaceId(workspaceId));
+    }
+
+    // 멤버 초대 취소
+    @DeleteMapping("/{workspaceId}/invites/{inviteId}")
+    public ResponseEntity<String> deleteInvite(@PathVariable Long workspaceId,
+                                               @PathVariable Long inviteId) {
+        adminService.deleteInviteByAdmin(workspaceId, inviteId);
+        return ResponseEntity.ok().body("관리자가 초대 취소를 하였습니다.");
     }
 }

--- a/src/main/java/onepick/kanban/user/service/AdminService.java
+++ b/src/main/java/onepick/kanban/user/service/AdminService.java
@@ -9,6 +9,7 @@ import onepick.kanban.user.entity.Role;
 import onepick.kanban.user.repository.MemberRepository;
 import onepick.kanban.workspace.dto.WorkspaceRequestDto;
 import onepick.kanban.workspace.dto.WorkspaceResponseDto;
+import onepick.kanban.workspace.entity.Invite;
 import onepick.kanban.workspace.entity.Workspace;
 import onepick.kanban.workspace.service.InviteService;
 import onepick.kanban.workspace.service.WorkspaceService;
@@ -60,6 +61,11 @@ public class AdminService {
         }
 
         return MemberRoleResponseDto.toDto(member);
+    }
+
+    @Transactional
+    public void deleteInviteByAdmin(Long workspaceId, Long inviteId) {
+        inviteService.deleteInviteByAdmin(workspaceId, inviteId);
     }
 
     public MemberResponseDto findMemberByWorkspaceId(Long workspaceId) {

--- a/src/main/java/onepick/kanban/workspace/controller/WorkspaceController.java
+++ b/src/main/java/onepick/kanban/workspace/controller/WorkspaceController.java
@@ -67,7 +67,7 @@ public class WorkspaceController {
     public ResponseEntity<String> deleteInvite(
             @PathVariable Long workspaceId,
             @PathVariable Long inviteId) {
-        inviteService.deleteInvite(workspaceId, inviteId);
+        inviteService.deleteInviteByStaff(workspaceId, inviteId);
         return ResponseEntity.ok().body("관리자가 초대 취소를 하였습니다.");
     }
 }

--- a/src/main/java/onepick/kanban/workspace/service/InviteService.java
+++ b/src/main/java/onepick/kanban/workspace/service/InviteService.java
@@ -113,9 +113,9 @@ public class InviteService {
         }
     }
 
-    // 관리자가 초대 취소
+    // STAFF 관리자가 초대 취소
     @Transactional
-    public void deleteInvite(Long workspaceId, Long inviteId) {
+    public void deleteInviteByStaff(Long workspaceId, Long inviteId) {
         Invite invite = inviteRepository.findById(inviteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 초대 ID입니다."));
 
@@ -129,9 +129,21 @@ public class InviteService {
 
         Optional<Member> member = memberService.findByWorkspaceIdAndUserId(workspaceId, inviter.get().getId());
 
-        if (member.get().getRole().equals(Role.STAFF) || inviter.get().getRole().equals(Role.ADMIN)) {
+        if (member.get().getRole().equals(Role.STAFF)) {
             inviteRepository.delete(invite);
         }
+    }
+
+    // 관리자가 초대 취소
+    public void deleteInviteByAdmin(Long workspaceId, Long inviteId) {
+        Invite invite = inviteRepository.findById(inviteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 초대 ID입니다."));
+
+        if (!invite.getWorkspace().getId().equals(workspaceId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 워크스페이스 ID입니다.");
+        }
+
+        inviteRepository.delete(invite);
     }
 
     private Workspace getWorkspace(Long workspaceId, List<String> emails) {


### PR DESCRIPTION
- ADMIN 관리자는 모든 워크스페이스 멤버 요청에 대해 자유롭게 취소 가능
- STAFF 관리자는 본인의 워크스페이스에 대해서만 멤버 요청 취소 가능