### PR TITLE
Feature/card

### DIFF
--- a/src/main/java/onepick/kanban/card/controller/CardAttachmentController.java
+++ b/src/main/java/onepick/kanban/card/controller/CardAttachmentController.java
@@ -1,40 +1,70 @@
-//package onepick.kanban.card.controller;
-//
-//import lombok.RequiredArgsConstructor;
-//import onepick.kanban.card.dto.CardAttachmentDto;
-//import onepick.kanban.card.service.CardAttachmentService;
-//import onepick.kanban.user.entity.User;
-//import onepick.kanban.user.repository.UserRepository;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.security.core.annotation.AuthenticationPrincipal;
-//import org.springframework.web.bind.annotation.DeleteMapping;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.PathVariable;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//import java.util.List;
-//
-//@RestController
-//@RequestMapping("/cards/{cardId}/attachments")
-//@RequiredArgsConstructor
-//public class CardAttachmentController {
-//
-//    private final CardAttachmentService attachmentService;
-//    private final UserRepository userRepository;
-//
-//    // 첨부파일 조회
-//    @GetMapping
-//    public ResponseEntity<List<CardAttachmentDto>> getAttachments(@PathVariable Long cardId, @AuthenticationPrincipal User user) {
-//        // 권한 검증 로직 추가
-//        List<CardAttachmentDto> attachments = attachmentService.getAttachments(cardId, user);
-//        return ResponseEntity.ok(attachments);
-//    }
-//
-//    // 첨부파일 삭제
-//    @DeleteMapping("/{attachmentId}")
-//    public ResponseEntity<Void> deleteAttachment(@PathVariable Long attachmentId, @AuthenticationPrincipal User user) {
-//        attachmentService.deleteAttachment(attachmentId, user);
-//        return ResponseEntity.noContent().build();
-//    }
-//}
+package onepick.kanban.card.controller;
+
+import lombok.RequiredArgsConstructor;
+import onepick.kanban.card.dto.CardAttachmentDto;
+import onepick.kanban.card.service.CardAttachmentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/cards/{cardId}/attachments")
+@RequiredArgsConstructor
+public class CardAttachmentController {
+
+    private final CardAttachmentService attachmentService;
+
+    /**
+     * 첨부파일 업로드
+     * @param cardId 카드 ID
+     * @param files  업로드할 파일 리스트
+     * @return 업로드된 첨부파일의 DTO 리스트
+     */
+    @PostMapping
+    public ResponseEntity<List<CardAttachmentDto>> uploadAttachments(
+            @PathVariable Long cardId,
+            @RequestParam("files") List<MultipartFile> files) {
+
+        // 첨부파일 업로드 및 저장
+        List<CardAttachmentDto> uploadedAttachments = attachmentService.createAttachments(cardId, files);
+        return ResponseEntity.status(HttpStatus.CREATED).body(uploadedAttachments);
+    }
+
+    /**
+     * 첨부파일 조회
+     * @param cardId 카드 ID
+     * @return 첨부파일의 DTO 리스트
+     */
+    @GetMapping
+    public ResponseEntity<List<CardAttachmentDto>> getAttachments(
+            @PathVariable Long cardId) {
+
+        List<CardAttachmentDto> attachments = attachmentService.getAttachments(cardId);
+        return ResponseEntity.ok(attachments);
+    }
+
+    /**
+     * 첨부파일 삭제
+     * @param cardId 카드 ID
+     * @param attachmentId 첨부파일 ID
+     * @return 응답 엔티티
+     */
+    @DeleteMapping("/{attachmentId}")
+    public ResponseEntity<Void> deleteAttachment(
+            @PathVariable Long cardId,
+            @PathVariable Long attachmentId) {
+
+        attachmentService.deleteAttachment(attachmentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/onepick/kanban/card/dto/CardAttachmentDto.java
+++ b/src/main/java/onepick/kanban/card/dto/CardAttachmentDto.java
@@ -9,6 +9,6 @@ public class CardAttachmentDto {
 
     private final Long id;
     private final String image;
-    private final String image_name;
+    private final String imageName;
     private final String fileType;
 }


### PR DESCRIPTION
**feat : CardAttachmentController 추가**

> 1. 첨부파일 업로드 (POST /cards/{cardId}/attachments):
>     * @PostMapping을 사용하여 첨부파일을 업로드한다.
>     * List<MultipartFile>을 @RequestParam("files")로 받아 여러 파일을 동시에 업로드할 수 있다.
>     * 업로드된 첨부파일의 DTO 리스트를 반환하며, HTTP 상태 코드는 201 CREATED로 설정한다.
> 2. 첨부파일 조회 (GET /cards/{cardId}/attachments):
>     * @GetMapping을 사용하여 특정 카드의 모든 첨부파일을 조회한다.
>     * 첨부파일의 DTO 리스트를 반환하며, HTTP 상태 코드는 200 OK로 설정한다.
> 3. 첨부파일 삭제 (DELETE /cards/{cardId}/attachments/{attachmentId}):
>     * @DeleteMapping("/{attachmentId}")을 사용하여 특정 첨부파일을 삭제한다.
>     * 성공적으로 삭제되면 HTTP 상태 코드는 204 NO CONTENT로 설정된다.
