### PR TITLE
fix: 워크스페이스 예외 처리 추가(조회 부분)

### DIFF
--- a/src/main/java/onepick/kanban/workspace/repository/WorkspaceRepository.java
+++ b/src/main/java/onepick/kanban/workspace/repository/WorkspaceRepository.java
@@ -6,9 +6,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
 
     @Query("SELECT w FROM Workspace w INNER JOIN FETCH w.members m WHERE w.id = :workspaceId")
     Workspace findMemberByWorkspaceId(@Param("workspaceId") Long workspaceId);
+
+    @Query("SELECT w FROM Workspace w INNER JOIN Member m ON m.workspace.id = w.id INNER JOIN User u ON u.id = m.user.id WHERE u.id = :userId")
+    List<Workspace> findWorkspacesByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
워크스페이스 조회
MEMBER 자신이 속한 워크스페이스만 전체 조회될 수 있도록 수정해야 함
어느 워크스페이스에도 속하지 않은 사용자일 경우, 조회 목록이 나오면 안 됨
본인이 속한 워크스페이스만 전체 조회되어야 함
유저5 사용자가 워크스페이스 1번과 2번에 속해 있다면 1번과 2번만 조회 되어야 함