### PR TITLE
Feature/card

### DIFF
--- a/src/main/java/onepick/kanban/card/controller/CardController.java
+++ b/src/main/java/onepick/kanban/card/controller/CardController.java
@@ -1,21 +1,17 @@
 package onepick.kanban.card.controller;
 
-import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import onepick.kanban.card.dto.CardRequestDto;
 import onepick.kanban.card.dto.CardResponseDto;
-import onepick.kanban.card.repository.CardRepository;
 import onepick.kanban.card.service.CardService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 
 @RestController
@@ -26,10 +22,18 @@ public class CardController {
     private final CardService cardService;
 
     // 카드 생성
-    @PostMapping
+    @PostMapping(consumes = "multipart/form-data")
     public ResponseEntity<CardResponseDto> createCard(@PathVariable Long boardId,
                                                       @PathVariable Long listId,
-                                                      @Valid @RequestBody CardRequestDto requestDto) {
+                                                      @RequestParam("title") @NotBlank(message = "제목을 입력해주세요.") String title,
+                                                      @RequestParam("contents") @NotBlank(message = "내용을 입력해주세요.") String contents,
+                                                      @RequestParam(value = "deadline", required = false) LocalDateTime deadline,
+                                                      @RequestParam(value = "assigneeIds", required = false) List<Long> assigneeIds,
+                                                      @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) {
+        // CardRequestDto 생성
+        CardRequestDto requestDto = new CardRequestDto(title, contents, deadline, assigneeIds, attachments);
+
+        // 카드 생성 및 첨부파일 처리
         CardResponseDto card = cardService.createCard(boardId, listId, requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(card);
@@ -46,9 +50,17 @@ public class CardController {
     }
 
     // 카드 수정
-    @PutMapping("/{cardId}")
+    @PutMapping(value = "/{cardId}", consumes = "multipart/form-data")
     public ResponseEntity<CardResponseDto> updateCard(@PathVariable Long cardId,
-                                                      @Valid @RequestBody CardRequestDto requestDto) {
+                                                      @RequestParam("title") @NotBlank(message = "제목을 입력해주세요.") String title,
+                                                      @RequestParam("contents") @NotBlank(message = "내용을 입력해주세요.") String contents,
+                                                      @RequestParam(value = "deadline", required = false) LocalDateTime deadline,
+                                                      @RequestParam(value = "assigneeIds", required = false) List<Long> assigneeIds,
+                                                      @RequestParam(value = "attachments", required = false) List<MultipartFile> attachments) {
+        // CardRequestDto 생성
+        CardRequestDto requestDto = new CardRequestDto(title, contents, deadline, assigneeIds, attachments);
+
+        // 카드 수정 및 첨부파일 처리
         CardResponseDto card = cardService.updateCard(cardId, requestDto);
 
         return ResponseEntity.ok(card);

--- a/src/main/java/onepick/kanban/card/dto/CardRequestDto.java
+++ b/src/main/java/onepick/kanban/card/dto/CardRequestDto.java
@@ -22,5 +22,7 @@ public class CardRequestDto {
 
     private final List<Long> assigneeIds; // 다중 담당자 ID
 
-    private List<String> attachmentUrls; // 첨부파일 URL 리스트
+    // 파일을 별도의 파라미터로 처리하고 필요시에 DTO와 함께 전달하는 것이 더 나은 방법
+    // 시간 부족으로 DTO에 직접 사용
+    private List<MultipartFile> attachments; // 첨부파일 리스트
 }

--- a/src/main/java/onepick/kanban/card/service/CardAttachmentService.java
+++ b/src/main/java/onepick/kanban/card/service/CardAttachmentService.java
@@ -76,7 +76,7 @@ public class CardAttachmentService {
                     .bucket(bucket)
                     .key(uniqueFileName)
                     .contentType(file.getContentType())
-                    .acl(ObjectCannedACL.PUBLIC_READ) // 파일을 공개적으로 읽을 수 있도록 설정
+//                    .acl(ObjectCannedACL.PUBLIC_READ) // 파일을 공개적으로 읽을 수 있도록 설정
                     .build();
 
             try {
@@ -84,6 +84,9 @@ public class CardAttachmentService {
             } catch (IOException exception) {
                 log.error("파일 업로드 중 오류가 발생했습니다: {}", exception.getMessage());
                 throw new RuntimeException("파일 업로드 중 오류가 발생했습니다.", exception);
+            } catch (Exception exception) {
+                exception.printStackTrace();
+                throw new RuntimeException(exception);
             }
 
             String fileUrl = getPublicUrl(uniqueFileName);

--- a/src/main/java/onepick/kanban/config/AwsConfig.java
+++ b/src/main/java/onepick/kanban/config/AwsConfig.java
@@ -29,6 +29,5 @@ public class AwsConfig {
                         StaticCredentialsProvider.create(
                                 AwsBasicCredentials.create(accessKey, secretKey)))
                 .build();
-
     }
 }


### PR DESCRIPTION
1. 카드 생성 시 클라이언트가 파일 직접 업로드하고, 
서버가 `CardAttachmentService`를 통해 S3에 업로드하고 데이터베이스에 저장
2. 파일 업로드 예외 처리 catch문 추가
3. `.acl(ObjectCannedACL.PUBLIC_READ)` 주석 처리